### PR TITLE
Detect movement also in the negative direction

### DIFF
--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -336,7 +336,7 @@ void LD2450Component::handle_periodic_data_(uint8_t *buffer, int len) {
     if (ss != nullptr) {
       val = this->decode_speed_(buffer[start], buffer[start + 1]);
       ts = val;
-      if (val > 0) {
+      if (val) {
         is_moving = true;
         moving_target_count++;
       }


### PR DESCRIPTION
# What does this implement/fix?

The moving_target_count value is only updated correctly if the object is moving *away*.
This PR makes it update moving_target_count also for movement in the other direction.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
